### PR TITLE
Remove author_email field from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ setup(
     long_description = readme,
     long_description_content_type = "text/markdown",
     author = package["author"]["name"],
-    author_email = package["author"]["email"],
     keywords = package["keywords"],
     packages = find_packages(),
     include_package_data = True,


### PR DESCRIPTION
Which was causing pip to fail on install after d316574 removed the field from `package.json`.