### PR TITLE
Remove python deps for publishing to pypi from install dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ This will set up all of the necessary packages to install the theme locally.
 ```sh
 git clone https://github.com/ponylang/mkdocs-theme
 cd mkdocs-theme
-python -m  venv venv
+python -m venv venv
 source venv/bin/activate
 pip install -e .
 npm install
@@ -97,12 +97,9 @@ npm run build
 
 ### Distribution
 
-Upload to PyPI with Twine:
-
-Remember to use the python from the virtualenv you created above.
+Upload to PyPI with Twine by calling the following Makefile targets:
 
 ```sh
-rm dist/*
-python setup.py sdist bdist_wheel
-twine upload dist/*
+make clean
+make upload-to-pypi
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,8 +26,3 @@ pymdown-extensions>=3.4
 
 # Markdown description support in Warehouse
 setuptools>=38.6.0
-
-# PyPI publishing
-twine>=1.11.0
-wheel>=0.31.0
-


### PR DESCRIPTION
those only need to be installed when doing a release.